### PR TITLE
Restrict numpy version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ data/
 
 # Venv
 venv/
+
+# Outputs
+outputs/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch>=2.0.0
 pytorch-lightning>=2.0.0
 torchmetrics>=1.0.0
-numpy>=1.24.0
+numpy>=1.24.0,<2.0.0
 pandas>=2.0.0
 pyyaml>=6.0.0
 hydra-core>=1.3.0


### PR DESCRIPTION
Avoid using numpy >= 2.0 to avoid incompatibility.

I got the following error when running the steps in the README:

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.2 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "/Users/ian/Documents/GitHub/CATHe2/src/train.py", line 3, in <module>
    import pytorch_lightning as pl
  File "/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/pytorch_lightning/__init__.py", line 25, in <module>
    from lightning_fabric.utilities.seed import seed_everything  # noqa: E402
  File "/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/lightning_fabric/__init__.py", line 35, in <module>
    from lightning_fabric.fabric import Fabric  # noqa: E402
  File "/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/lightning_fabric/fabric.py", line 29, in <module>
    import torch
  File "/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/torch/__init__.py", line 1477, in <module>
    from .functional import *  # noqa: F403
  File "/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/torch/functional.py", line 9, in <module>
    import torch.nn.functional as F
  File "/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/torch/nn/__init__.py", line 1, in <module>
    from .modules import *  # noqa: F403
  File "/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/torch/nn/modules/__init__.py", line 35, in <module>
    from .transformer import TransformerEncoder, TransformerDecoder, \
  File "/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/torch/nn/modules/transformer.py", line 20, in <module>
    device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
/Users/ian/Documents/GitHub/CATHe2/venv/lib/python3.9/site-packages/torch/nn/modules/transformer.py:20: UserWarning: Failed to initialize NumPy: _ARRAY_API not found (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
  device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
[2025-02-05 13:24:43,642][rich][ERROR] - Error loading data: Numpy is not available
```

It looks like this was due to inconsistencies with torch and numpy 2.0 (the latter was in my pip cache from other work and was therefore preferentially selected by pip during install). 